### PR TITLE
Support glob pattern in deps

### DIFF
--- a/diff.go
+++ b/diff.go
@@ -3,7 +3,6 @@ package monodiff
 import (
 	"errors"
 	"sort"
-	"strings"
 )
 
 func detectChanges(spec *Spec, changedFiles []string) ([]*Project, error) {
@@ -32,7 +31,7 @@ func detectChanges(spec *Spec, changedFiles []string) ([]*Project, error) {
 
 		if !isChanged {
 			for _, filesDependency := range project.FilesDependencies {
-				if matchPattern(changedFiles, filesDependency.GlobPattern) {
+				if matchPattern(filesDependency.GlobPattern, changedFiles) {
 					isChanged = true
 					break
 				}
@@ -98,15 +97,6 @@ func sortProjects(projects []*Project) ([]*Project, error) {
 		}
 	}
 	return sortedProjects, nil
-}
-
-func matchPattern(changedFiles []string, globPattern string) bool {
-	for _, changedFile := range changedFiles {
-		if changedFile == globPattern || strings.HasPrefix(changedFile, globPattern+"/") {
-			return true
-		}
-	}
-	return false
 }
 
 func projectNames(projects []*Project) []string {

--- a/diff_test.go
+++ b/diff_test.go
@@ -28,6 +28,18 @@ var filesDependencySpec = &Spec{
 	},
 }
 
+var patternDependencySpec = &Spec{
+	Projects: []*Project{
+		{
+			Name: "main",
+			FilesDependencies: []FilesDependency{
+				{"main"},
+				{"package*.json"},
+			},
+		},
+	},
+}
+
 var projectDependencySpec = &Spec{
 	Projects: []*Project{
 		{
@@ -129,6 +141,16 @@ func TestDetectNoChangesWhenFilesOutOfFilesDependencyAreChanged(t *testing.T) {
 	}
 	if len(changedProjects) != 0 {
 		t.Fatal("changedProjects must be empty")
+	}
+}
+
+func TestDetectPatternDependency(t *testing.T) {
+	changedProjects, err := detectChanges(patternDependencySpec, []string{"package.json"})
+	if err != nil {
+		t.Fatalf("failed test %#v", err)
+	}
+	if !reflect.DeepEqual(projectNames(changedProjects), []string{"main"}) {
+		t.Fatal("changedProjects does not match")
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/orangain/monodiff
 
 go 1.14
 
-require github.com/urfave/cli/v2 v2.2.0
+require (
+	github.com/gobwas/glob v0.2.3
+	github.com/urfave/cli/v2 v2.2.0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d h1:U+s90UTSYgptZMwQh2aRr3LuazLJIa+Pg3Kc1ylSYVY=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
+github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
+github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/russross/blackfriday/v2 v2.0.1 h1:lPqVAte+HuHNfhJ/0LC98ESWRz8afy9tM/0RK8m9o+Q=

--- a/match.go
+++ b/match.go
@@ -1,10 +1,16 @@
 package monodiff
 
-import "strings"
+import (
+	"github.com/gobwas/glob"
+)
 
 func matchPattern(globPattern string, paths []string) bool {
+	sep := '/'
+	globFile := glob.MustCompile(globPattern, sep)      // Exact match
+	globDir := glob.MustCompile(globPattern+"/**", sep) // Prefix match
+
 	for _, path := range paths {
-		if path == globPattern || strings.HasPrefix(path, globPattern+"/") {
+		if globFile.Match(path) || globDir.Match(path) {
 			return true
 		}
 	}

--- a/match.go
+++ b/match.go
@@ -1,0 +1,12 @@
+package monodiff
+
+import "strings"
+
+func matchPattern(globPattern string, paths []string) bool {
+	for _, path := range paths {
+		if path == globPattern || strings.HasPrefix(path, globPattern+"/") {
+			return true
+		}
+	}
+	return false
+}

--- a/match_test.go
+++ b/match_test.go
@@ -1,0 +1,38 @@
+package monodiff
+
+import "testing"
+
+type singleInputTest struct {
+	expected  bool
+	pattern   string
+	inputPath string
+}
+
+func TestEmptyPatternMatch(t *testing.T) {
+	result := matchPattern("src", []string{})
+	if result != false {
+		t.Fatal("should not match empty paths")
+	}
+}
+
+func TestSinglePatternMatch(t *testing.T) {
+	tests := []singleInputTest{
+		{true, "src", "src/index.js"},
+		{true, "src", "src"},
+		{false, "src", "sr"},
+		{false, "src", "src.txt"},
+		{false, "src", "dist/index.js"},
+		{false, "src", "README.md"},
+	}
+
+	for _, test := range tests {
+		result := matchPattern(test.pattern, []string{test.inputPath})
+		if result != test.expected {
+			if test.expected {
+				t.Fatalf("expected pattern %#v should match input %#v but not matched", test.pattern, test.inputPath)
+			} else {
+				t.Fatalf("expected pattern %#v should not match input %#v but matched", test.pattern, test.inputPath)
+			}
+		}
+	}
+}

--- a/match_test.go
+++ b/match_test.go
@@ -21,8 +21,38 @@ func TestSinglePatternMatch(t *testing.T) {
 		{true, "src", "src"},
 		{false, "src", "sr"},
 		{false, "src", "src.txt"},
+		{false, "src", "src2/index.js"},
+		{false, "src", "old_src/index.js"},
 		{false, "src", "dist/index.js"},
 		{false, "src", "README.md"},
+		{true, "package-lock.json", "package-lock.json"},
+		{true, "package-lock.json", "package-lock.json/foo"},
+		{false, "package-lock.json", "package-lock.json5"},
+		{true, "package*.json", "package-lock.json"},
+		{true, "package*.json", "package.json"},
+		{false, "package*.json", "package/config.json"},
+		{true, "**/build.gradle.kts", "libs/build.gradle.kts"},
+		{true, "**/build.gradle.kts", "libs/profile/build.gradle.kts"},
+		{false, "**/build.gradle.kts", "build.gradle.kts"},          // Pattern "**/" requires "/"
+		{true, "libs/**/build.gradle.kts", "libs/build.gradle.kts"}, // Pattern "/**/" does not require "//"
+		{true, "libs/**/build.gradle.kts", "libs/profile/build.gradle.kts"},
+		{true, "libs/**/build.gradle.kts", "libs/profile/util/build.gradle.kts"},
+		{true, "*", "foo.txt"},
+		{true, "*", "test/foo.txt"}, // Pattern "*" matches any directory and files under the directory. So it is equivalent to "**"
+		{true, "*.bak", "foo.bak"},
+		{true, "*.bak", "foo.bak/bar.txt"},
+		{false, "*.bak", "foo/bar.bak"},
+		{true, "index*", "index"},
+		{true, "index*", "index.js"},
+		{true, "index*", "index.d/foo"},
+		{true, "**", "foo.txt"},
+		{true, "**", "test/foo.txt"},
+		{true, "**.bak", "foo.bak"},
+		{true, "**.bak", "foo.bak/bar.txt"},
+		{true, "**.bak", "foo/bar.bak"},
+		{true, "index**", "index"},
+		{true, "index**", "index.js"},
+		{true, "index**", "index.d/foo"},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Now you can write a glob pattern in `deps` of `monodiff.json`.