### PR TITLE
Hide help command

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,13 +1,13 @@
-name: release
+name: build
 on:
   push:
-    tags:
-    - "v[0-9]+.[0-9]+.[0-9]+"
+    branches:
+    - "**"
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - uses: actions/setup-go@v1
         with:
           go-version: 1.14
@@ -15,6 +15,4 @@ jobs:
       - uses: goreleaser/goreleaser-action@v1
         with:
           version: latest
-          args: release --rm-dist
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          args: release --snapshot --skip-publish --rm-dist

--- a/app.go
+++ b/app.go
@@ -11,8 +11,10 @@ import (
 
 // App is a CLI app of monodiff using urfave/cli/v2.
 var App = &cli.App{
-	Name:  "monodiff",
-	Usage: "Simple tool to detect modified part of monorepo",
+	Name:            "monodiff",
+	HelpName:        "monodiff",
+	Usage:           "Simple tool to detect modified part of monorepo",
+	HideHelpCommand: true,
 	Flags: []cli.Flag{
 		&cli.StringFlag{
 			Name:  "prefix",


### PR DESCRIPTION
Remove help command from help message.

```
$ go run cmd/monodiff/main.go -help
NAME:
   monodiff - Simple tool to detect modified part of monorepo

USAGE:
   monodiff [global options] [arguments...]

VERSION:
   unset (unset)

GLOBAL OPTIONS:
   --prefix value     Prefix of output line
   --suffix value     Suffix of output line
   --separator value  Path separator of output line
   --help, -h         show help (default: false)
   --version, -v      print the version (default: false)
```